### PR TITLE
Add initial configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 1
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      timezone: "America/Toronto"
+
+    labels:
+      - "dependencies"
+
+    reviewers:
+      - "Seneca-CDOT/osd700-dps911-winter-2023"
+
+    open-pull-requests-limit: 5
+    # disable auto rebasing
+    rebase-strategy: "disabled"


### PR DESCRIPTION
## Description
This PR resolves #42 by providing the initial configuration for Dependabot to update `npm` packages and create a PR. I have:
- Set the reviewing team to be the current members of Seneca-CDOT/osd700-dps911-winter-2023
- Capped open PRs by Dependabot to 5
- Disabled auto rebasing
- Scheduld checks/PRs to held weekly on Saturday, Toronto time

I tried to closely configure Dependabot based on how Telescope has renovatebot set up.