### PR TITLE
chore: remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     labels:
       - "dependencies"
 
-    reviewers:
-      - "Seneca-CDOT/osd700-dps911-winter-2023"
+    # reviewers:
+      # - "Seneca-CDOT/osd700-dps911-winter-2023"
 
     open-pull-requests-limit: 5
     # disable auto rebasing

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     labels:
       - "dependencies"
 
-    # reviewers:
-    # - "Seneca-CDOT/osd700-dps911-winter-2023"
-
     open-pull-requests-limit: 5
     # disable auto rebasing
     rebase-strategy: "disabled"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - "dependencies"
 
     # reviewers:
-      # - "Seneca-CDOT/osd700-dps911-winter-2023"
+    # - "Seneca-CDOT/osd700-dps911-winter-2023"
 
     open-pull-requests-limit: 5
     # disable auto rebasing


### PR DESCRIPTION
Remove dependabot requesting reviewers. Reviewing those PRs should be the sheriffs responsibility
