### PR TITLE
ci: cancel all jobs on failure (#83)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   Build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,6 +37,10 @@ jobs:
       - name: Run build
         run: npm run build
 
+      - name: Cancel build if failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -45,6 +50,7 @@ jobs:
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
   Prettier:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -55,7 +61,12 @@ jobs:
         with:
           prettier_options: --check .
 
+      - name: Cancel build if failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
   Test:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -84,6 +95,10 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Cancel build if failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -93,6 +108,7 @@ jobs:
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
   ESlint:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -121,6 +137,10 @@ jobs:
       - name: eslint check
         run: npm run lint
 
+      - name: Cancel build if failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
+
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -130,6 +150,7 @@ jobs:
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
   Typecheck:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -157,6 +178,10 @@ jobs:
 
       - name: Run typecheck
         run: npm run typecheck
+
+      - name: Cancel build if failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
 
       - name: Cache node_modules
         uses: actions/cache@v3


### PR DESCRIPTION
Cancel all other CI jobs if one job fails.

(Re-applying @shawnyu5's a1fb786125ddfc135a939010286437cb049f4fdd commit, which got lost when we fixed up #94)