### PR TITLE
Use consistent naming for CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         if: failure()
         uses: andymckay/cancel-action@0.2
 
-  Test:
+  Unit-Tests:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +107,7 @@ jobs:
             # cache node modules using the same key as restore.
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
-  E2E-Test:
+  E2E-Tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     services:
@@ -214,7 +214,7 @@ jobs:
             # cache node modules using the same key as restore.
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
-  Typecheck:
+  Type-Check:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Minor naming cleanup for CI job names.