### PR TITLE
Dependabot: ignore major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     open-pull-requests-limit: 5
     # disable auto rebasing
     rebase-strategy: 'disabled'
+
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Description
This PR resolves #71 by ignoring `major` version updates. Dependabot will be restricted from raising PR for riskier updates, such as migrating from version `0.X.X` to `2.X.X` for any dependency. 

#### Resource
- https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/