### PR TITLE
Setup MailHog in Docker to send test notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ PORT=8080
 
 # One of: trace, debug, info, warn, error, fatal, silent
 LOG_LEVEL=debug
+
+# Nodemailer config
+NOTIFICATIONS_EMAIL_USER="no-reply@senecacollege.ca"
+MAILHOG_SMTP_PORT=1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,3 +46,10 @@ services:
       # If we decide to implement challenges in testing:
       # https://github.com/letsencrypt/pebble/blob/main/cmd/pebble-challtestsrv/README.md
       PEBBLE_VA_ALWAYS_VALID: 1
+
+  mailhog:
+    image: mailhog/mailhog
+    container_name: mailhog
+    ports:
+      - 8025:8025 # MailHog interface
+      - 1025:1025 # SMTP server


### PR DESCRIPTION
## Description
This PR resolves #126 by setting up MailHog in Docker to test sending notification emails in the development environment.

#### Steps to Test
1. `cp .env.example .env`
2. `npm run docker`
3.  `npm run setup`
4. `npm run build`
5. `npm run dev`
6. Navigate to MailHog UI at `localhost:8025`:
<img width="1448" alt="Screenshot 2023-02-07 at 9 43 20 PM" src="https://user-images.githubusercontent.com/50856799/217308483-7efee858-87cf-4fbf-9c9d-c0b8ecd6800b.png">

#### Additional Information
There are currently no tests implemented to check whether we are able to send notifications successfully. I intend on implementing tests for notifications in a follow-up PR. 