### PR TITLE
Update Nodemailer production transport options for testing

### DIFF
--- a/app/lib/notifications.server.ts
+++ b/app/lib/notifications.server.ts
@@ -5,26 +5,26 @@ import logger from './logger.server';
 import type { SendMailOptions } from 'nodemailer';
 
 const { NOTIFICATIONS_EMAIL_USER, NODE_ENV, MAILHOG_SMTP_PORT } = process.env;
-const { NODEMAILER_CLIENT_ID, NODEMAILER_ACCESS_TOKEN } = secrets ?? {};
+const { NOTIFICATIONS_USERNAME, NOTIFICATIONS_PASSWORD } = secrets ?? {};
 
 const initializeTransport = () => {
   if (!NOTIFICATIONS_EMAIL_USER) {
     throw new Error('Missing Nodemailer user. Skipping nodemailer configuration');
   }
   if (NODE_ENV === 'production') {
-    if (!NODEMAILER_CLIENT_ID || !NODEMAILER_ACCESS_TOKEN) {
+    if (!NOTIFICATIONS_USERNAME || !NOTIFICATIONS_PASSWORD) {
       throw new Error(
-        'Missing Nodemailer environment variables or docker secrets. Skipping nodemailer configuration'
+        'Missing NOTIFICATIONS_USERNAME and/or NOTIFICATIONS_PASSWORD env variables. Skipping nodemailer configuration'
       );
     }
     return createTransport({
-      service: 'Outlook365',
+      host: 'smtp.office365.com',
+      port: 587,
       auth: {
-        type: 'OAuth2',
-        user: NOTIFICATIONS_EMAIL_USER, // email address for notifications
-        clientId: NODEMAILER_CLIENT_ID,
-        accessToken: NODEMAILER_ACCESS_TOKEN,
+        user: NOTIFICATIONS_USERNAME,
+        pass: NOTIFICATIONS_PASSWORD,
       },
+      requireTLS: true,
     });
   }
   return createTransport({
@@ -32,7 +32,7 @@ const initializeTransport = () => {
   });
 };
 
-const send = async (data: SendMailOptions) => {
+const sendNotification = async (data: SendMailOptions) => {
   try {
     const transport = initializeTransport();
     logger.debug('Sending notification', data);
@@ -42,4 +42,4 @@ const send = async (data: SendMailOptions) => {
   }
 };
 
-export default send;
+export default sendNotification;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "helmet": "^6.0.1",
         "is-ip": "^5.0.0",
         "isbot": "^3.6.5",
+        "nodemailer": "^6.9.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tiny-invariant": "^1.3.1",
@@ -16099,6 +16100,14 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
       "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -32827,6 +32836,11 @@
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.9.tgz",
       "integrity": "sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA=="
+    },
+    "nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "helmet": "^6.0.1",
     "is-ip": "^5.0.0",
     "isbot": "^3.6.5",
+    "nodemailer": "^6.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tiny-invariant": "^1.3.1",


### PR DESCRIPTION
## Description
This PR resolves #149 by updating the `production` transport options with the following settings:
- host: `smtp.office365.com`
- port: `587`
- auth (accepts username, pass)
- requireTLS: `true  // forces STARTTLS`