### PR TITLE
Improve and secure Dockerfile for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
+/.github
+/.vscode
+/img
+/e2e/
+/mysql-data
 /node_modules
+/playwright-report
+/test
 *.log
 .DS_Store
 .env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,16 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-cache-restore.outputs.cache-primary-key }}
 
+  Dockerfile-Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run Hadolint on Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+
   ESlint:
     runs-on: ubuntu-latest
     steps:

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@prisma/client';
-import invariant from 'tiny-invariant';
 import logger from '~/lib/logger.server';
 
 let prisma: PrismaClient;
@@ -23,7 +22,9 @@ if (process.env.NODE_ENV === 'production') {
 
 function getClient() {
   const { DATABASE_URL } = process.env;
-  invariant(typeof DATABASE_URL === 'string', 'DATABASE_URL env var not set');
+  if (typeof DATABASE_URL !== 'string') {
+    throw new Error('DATABASE_URL env var not set');
+  }
 
   const databaseUrl = new URL(DATABASE_URL);
 

--- a/app/lib/logger.server.ts
+++ b/app/lib/logger.server.ts
@@ -15,4 +15,16 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
 });
 
+// https://nodejs.org/api/process.html#event-uncaughtexception
+process.on('uncaughtException', (err, origin) => {
+  logger.error('uncaughtException', err, origin);
+  throw err;
+});
+
+// https://nodejs.org/api/process.html#event-unhandledrejection
+process.on('unhandledRejection', (reason, promise) => {
+  logger.error('unhandledRejection', reason, promise);
+  throw reason;
+});
+
 export default logger;

--- a/app/routes/healthcheck.tsx
+++ b/app/routes/healthcheck.tsx
@@ -1,7 +1,7 @@
 // learn more: https://fly.io/docs/reference/configuration/#services-http_checks
 import type { LoaderArgs } from '@remix-run/server-runtime';
+import { json } from '@remix-run/server-runtime';
 import { prisma } from '~/db.server';
-import logger from '~/lib/logger.server';
 
 export async function loader({ request }: LoaderArgs) {
   const host = request.headers.get('X-Forwarded-Host') ?? request.headers.get('host');
@@ -18,8 +18,8 @@ export async function loader({ request }: LoaderArgs) {
         }
       }),
     ]);
+    return json({ status: 'ok ' });
   } catch (error: unknown) {
-    logger.warn('healthcheck ❌', error);
-    return new Response('ERROR', { status: 500 });
+    return json({ status: 'error' }, { status: 500 });
   }
 }

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,10 +1,11 @@
 import { createCookieSessionStorage, redirect } from '@remix-run/node';
-import invariant from 'tiny-invariant';
 
 import type { User } from '~/models/user.server';
 import { getUserByUsername } from '~/models/user.server';
 
-invariant(process.env.SESSION_SECRET, 'SESSION_SECRET must be set');
+if (typeof process.env.SESSION_SECRET !== 'string') {
+  throw new Error('SESSION_SECRET env var must be set');
+}
 
 export const sessionStorage = createCookieSessionStorage({
   cookie: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@senecacdot/starchart",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.261.0",
         "@chakra-ui/react": "^2.4.9",


### PR DESCRIPTION
Fixes #116

This updates the Dockerfile from the Blue Stack.  It improves a bunch of things in terms security, size, optimization, and best practices.

You can test it by adding the following `service` to `docker-compose.yml` file:

```yml
  starchart:
    build: .
    # NOTE: the container will crash and restart a bunch of times while MySQL comes up
    restart: always
    ports:
      - 8080:8080
    environment:
      DATABASE_URL: 'mysql://starchart:starchart_password@database:3306/starchart'
      SESSION_SECRET: 'super-duper-secret!!!!!!'
```

You should now be able to go to http://localhost:8080.  If you run `docker ps` you should see the `starchart` container, and its status should eventually say `healthy`.

I've also added a CI step to lint the Dockerfile.

While I was doing this I notice that the `invariant()` calls are having the string value stripped in production builds.  In some cases this won't matter (e.g., where we catch the exception), but during so during startup sucks, since you lose info.  I've changed to manually throw the error + message.