### PR TITLE
fix: mailhog container not working on M1 Mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       PEBBLE_VA_ALWAYS_VALID: 1
 
   mailhog:
-    image: mailhog/mailhog
+    image: jcalonso/mailhog:latest
     container_name: mailhog
     ports:
       - 8025:8025 # MailHog interface


### PR DESCRIPTION
## Description
Fixes #158 

### Steps to Test
1. `npm run docker`
2. navigate to `localhost:8025`

