### PR TITLE
Tweak login styles

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, chakra } from '@chakra-ui/react';
 import type { LoaderArgs, MetaFunction } from '@remix-run/node';
 import { json } from '@remix-run/node';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
@@ -20,18 +20,18 @@ export async function loader({ request }: LoaderArgs) {
 
 function Document({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <chakra.html lang="en" minHeight="full">
       <head>
         <Meta />
         <Links />
       </head>
-      <body>
+      <chakra.body minHeight="full">
         {children}
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
-      </body>
-    </html>
+      </chakra.body>
+    </chakra.html>
   );
 }
 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -16,20 +16,22 @@ export const action = async ({ request }: ActionArgs) => {
 
 export default function Login() {
   return (
-    <Center height="container.md" marginTop="16">
+    <Center height="full">
       <Grid gap="12">
         <GridItem width="lg">
-          <VStack marginTop="20" spacing="10">
+          <VStack spacing="10">
             <Heading size="2xl" color="brand.500">
               My.Custom.Domain
             </Heading>
-            <Text fontSize="3xl">Simple, Secure, DNS for Seneca</Text>
+            <Text fontSize="3xl" color="gray.600">
+              Simple, Secure, DNS for Seneca
+            </Text>
           </VStack>
         </GridItem>
         <GridItem border="solid" borderRadius="2xl" borderColor="brand.500">
           <VStack height="2xs">
             <Flex width="100px" height="100px" marginTop="10">
-              <LockIcon color="grey" boxSize="100%" />
+              <LockIcon color="gray.600" boxSize="100%" />
             </Flex>
             <Flex flex={1} alignItems="center" justifyContent="center">
               <Form method="post">


### PR DESCRIPTION
This makes a few adjustments to the login and root routes.

1. I've set a `min-height` on the `html` and `body` so they always fill 100% of the available hight
2. I've centred the login components vertically in the screen, so it works at all sizes
3. I've darkened the gray we use, and repeated it for the secondary text

Here's what it looks like, but you really need to try in a window you can resize:

<img width="1179" alt="Screenshot 2023-02-12 at 5 26 01 PM" src="https://user-images.githubusercontent.com/427398/218341055-cb169040-64b0-4408-a6cc-9883461a482d.png">
